### PR TITLE
Actualizar la creación de sorteo , evento opcional 

### DIFF
--- a/src/components/DateTimePickerInlineLottery.tsx
+++ b/src/components/DateTimePickerInlineLottery.tsx
@@ -1,0 +1,105 @@
+import { Calendar } from "@/components/ui/calendar";
+import { Button } from "@/components/ui/button";
+import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
+import { format } from "date-fns";
+import { useEffect, useRef, useState } from "react";
+
+export function DateTimePickerInlineLottery({
+  value,
+  onChange,
+}: {
+  value: Date;
+  onChange: (date: Date) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  function handleTimeChange(type: "hour" | "minute", valueNum: number) {
+    const newDate = new Date(value);
+    if (type === "hour") newDate.setHours(valueNum);
+    if (type === "minute") newDate.setMinutes(valueNum);
+    onChange(newDate);
+  }
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        wrapperRef.current &&
+        !wrapperRef.current.contains(event.target as Node)
+      ) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  return (
+    <div className="relative" ref={wrapperRef}>
+      <Button
+        type="button"
+        variant="outline"
+        onClick={() => setOpen(!open)}
+        className="w-full justify-start pl-3 text-left font-normal bg-secondary border-[#9A7FFF] focus:border-[#9A7FFF] focus:ring-[#9A7FFF] font-poopins"
+      >
+        {format(value, "dd/MM/yyyy HH:mm")}
+      </Button>
+
+      {open && (
+        <div className="absolute top-full mt-2 z-50 bg-white shadow-md rounded-md p-0 flex w-fit">
+          <Calendar
+            mode="single"
+            selected={value}
+            onSelect={(date) => {
+              if (date) {
+                onChange(date);
+              }
+            }}
+          />
+
+          <div className="flex max-h-[280px]">
+            <div>
+              <ScrollArea className="h-full w-fit rounded border-r">
+                <div className="flex flex-col gap-1 p-2">
+                  {Array.from({ length: 24 }, (_, i) => (
+                    <Button
+                      key={i}
+                      variant={value.getHours() === i ? "default" : "ghost"}
+                      size="default"
+                      type="button"
+                      className="w-fit p-0 aspect-square"
+                      onClick={() => handleTimeChange("hour", i)}
+                    >
+                      {i.toString().padStart(2, "0")}
+                    </Button>
+                  ))}
+                </div>
+                <ScrollBar orientation="vertical" />
+              </ScrollArea>
+            </div>
+
+            <div>
+              <ScrollArea className="h-full w-fit rounded">
+                <div className="flex flex-col gap-1 p-2">
+                  {Array.from({ length: 12 }, (_, i) => i * 5).map((m) => (
+                    <Button
+                      key={m}
+                      variant={value.getMinutes() === m ? "default" : "ghost"}
+                      size="default"
+                      className="w-fit p-0 aspect-square"
+                      type="button"
+                      onClick={() => handleTimeChange("minute", m)}
+                    >
+                      {m.toString().padStart(2, "0")}
+                    </Button>
+                  ))}
+                </div>
+                <ScrollBar orientation="vertical" />
+              </ScrollArea>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/lottery/components/addLottery.tsx
+++ b/src/pages/lottery/components/addLottery.tsx
@@ -36,7 +36,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useEventStore } from "@/pages/events/lib/event.store";
-import { DateTimePickerInline } from "@/components/DateTimePickerInline";
 import RichTextEditor from "@/components/RichTextEditor";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
@@ -44,6 +43,7 @@ import { createRaffle } from "../lib/lottery.actions";
 import { LotteryItem } from "../lib/lottery.interface";
 import { useLotteryStore } from "../lib/lottery.store";
 import { errorToast, successToast } from "@/lib/core.function";
+import { DateTimePickerInlineLottery } from "@/components/DateTimePickerInlineLottery";
 
 const PrizeSchema = z.object({
   name: z.string().nonempty("El nombre del premio es obligatorio"),
@@ -56,9 +56,11 @@ const LotterySchema = z.object({
   lottery_name: z.string().nonempty("El nombre de la lotería es obligatorio"),
   lottery_description: z.string().nonempty("La descripción es obligatoria"),
   lottery_date: z.date({ required_error: "La fecha es obligatoria" }),
-  event_id: z.number().min(1, {
-    message: "Debe seleccionar un evento",
-  }),
+  // event_id: z.number().min(1, {
+  //   message: "Debe seleccionar un evento",
+  // }),
+  event_id: z.number().optional().nullable(),
+
   lottery_price: z
     .string()
     .refine((val) => !isNaN(Number(val)) && Number(val) > 0, {
@@ -100,7 +102,7 @@ export default function CreateLotteryForm({
       lottery_name: "",
       lottery_date: new Date(),
       lottery_description: "",
-      event_id: 0,
+      event_id: undefined, // antes era 0
       lottery_price: "",
       price_factor_consumo: "",
       number_of_prizes: "",
@@ -149,7 +151,11 @@ export default function CreateLotteryForm({
       formData.append("lottery_name", data.lottery_name);
       formData.append("lottery_description", data.lottery_description);
       formData.append("lottery_date", formattedDate);
-      formData.append("event_id", data.event_id.toString());
+      // formData.append("event_id", data.event_id.toString());
+      if (data.event_id) {
+        formData.append("event_id", data.event_id.toString());
+      }
+
       formData.append("lottery_price", data.lottery_price);
       if (data.price_factor_consumo) {
         formData.append("price_factor_consumo", data.price_factor_consumo);
@@ -176,8 +182,10 @@ export default function CreateLotteryForm({
       successToast("Sorteo creada exitosamente");
       onClose();
     } catch (error: any) {
-     console.error("Error capturado:", error); 
-      const errorMessage = error?.response?.data?.message || "Ocurrió un error al guardar el sorteo";
+      console.error("Error capturado:", error);
+      const errorMessage =
+        error?.response?.data?.message ||
+        "Ocurrió un error al guardar el sorteo";
       errorToast(errorMessage);
     } finally {
       setIsSubmitting(false);
@@ -254,7 +262,7 @@ export default function CreateLotteryForm({
                           disabled={selectedCompanyId === 0}
                         >
                           <SelectTrigger className="border-[#9A7FFF] focus:ring-[#9A7FFF] font-poopins">
-                            <SelectValue placeholder="Seleccionar evento" />
+                            <SelectValue placeholder="Seleccionar evento opcional" />
                           </SelectTrigger>
                           <SelectContent>
                             {eventosDisponibles.length === 0 ? (
@@ -376,7 +384,7 @@ export default function CreateLotteryForm({
                       <FormLabel className="text-sm font-normal font-poopins">
                         Fecha y Hora
                       </FormLabel>
-                      <DateTimePickerInline
+                      <DateTimePickerInlineLottery
                         value={field.value}
                         onChange={(date) => form.setValue("lottery_date", date)}
                       />

--- a/src/pages/lottery/components/lotteryPage.tsx
+++ b/src/pages/lottery/components/lotteryPage.tsx
@@ -68,12 +68,13 @@ export default function LotteryPage() {
     if (!companyId || companyId === 0) {
       navigate("/empresas");
     } else {
-      loadRaffles(companyId);
+      // loadRaffles(companyId);
+      loadRaffles(1, companyId);
     }
   }, [companyId, loadRaffles, navigate]);
 
   const handlePageChange = (page: number) => {
-    loadRaffles(companyId, page);
+    loadRaffles(page, companyId);
   };
 
   const handleEditLottery = (lottery: LotteryItem) => {
@@ -363,7 +364,11 @@ export default function LotteryPage() {
                         </Button>
                       </TableCell>
                       <TableCell className="text-center">
-                        {lottery.event_name}
+                        <Badge className="font-inter" variant="secondary">
+                          {lottery.event_name
+                            ? lottery.event_name
+                            : "Evento no vinculado"}
+                        </Badge>
                       </TableCell>
                       <TableCell className="text-center">
                         <Badge
@@ -471,7 +476,7 @@ export default function LotteryPage() {
                   onClose={() => {
                     setIsEditDialogOpen(false);
                     setLotteryToEdit(null);
-                    loadRaffles(companyId);
+                    loadRaffles(1, companyId);
                   }}
                 />
               </DialogContent>

--- a/src/pages/lottery/components/updateLottery.tsx
+++ b/src/pages/lottery/components/updateLottery.tsx
@@ -30,7 +30,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-import { DateTimePickerInline } from "@/components/DateTimePickerInline";
+// import { DateTimePickerInline } from "@/components/DateTimePickerInline";
 import RichTextEditor from "@/components/RichTextEditor";
 import { useComapanyStore } from "@/pages/company/lib/company.store";
 import { useEventStore } from "@/pages/events/lib/event.store";
@@ -38,6 +38,7 @@ import { useLotteryStore } from "../lib/lottery.store";
 import { errorToast, successToast } from "@/lib/core.function";
 import { LotteryItem } from "../lib/lottery.interface";
 import { updateRaffle } from "../lib/lottery.actions";
+import { DateTimePickerInlineLottery } from "@/components/DateTimePickerInlineLottery";
 
 const PrizeSchema = z.object({
   name: z.string().nonempty("El nombre del premio es obligatorio"),
@@ -50,7 +51,7 @@ const LotterySchema = z.object({
   lottery_name: z.string().nonempty("El nombre de la lotería es obligatorio"),
   lottery_description: z.string().nonempty("La descripción es obligatoria"),
   lottery_date: z.date(),
-  event_id: z.number().min(1, { message: "Debe seleccionar un evento" }),
+  event_id: z.number().optional().nullable(),
   lottery_price: z
     .string()
     .refine((val) => !isNaN(Number(val)) && Number(val) > 0, {
@@ -101,7 +102,7 @@ export default function UpdateLotteryForm({
       lottery_name: lottery.lottery_name,
       lottery_description: lottery.lottery_description,
       lottery_date: new Date(lottery.lottery_date),
-      event_id: lottery.event_id,
+      event_id: lottery.event_id ?? null,
       lottery_price: lottery.lottery_price,
       price_factor_consumo:
         lottery.lottery_by_event?.price_factor_consumo || "",
@@ -146,7 +147,9 @@ export default function UpdateLotteryForm({
       formData.append("lottery_name", data.lottery_name);
       formData.append("lottery_description", data.lottery_description);
       formData.append("lottery_date", formattedDate);
-      formData.append("event_id", data.event_id.toString());
+      if (data.event_id) {
+        formData.append("event_id", data.event_id.toString());
+      }
       formData.append("lottery_price", data.lottery_price);
       if (data.price_factor_consumo) {
         formData.append("price_factor_consumo", data.price_factor_consumo);
@@ -171,7 +174,8 @@ export default function UpdateLotteryForm({
     } catch (error: any) {
       console.error("Error capturado:", error);
       const errorMessage =
-        error?.response?.data?.message || "Ocurrió un error al guardar el sorteo";
+        error?.response?.data?.message ||
+        "Ocurrió un error al guardar el sorteo";
       errorToast(errorMessage);
     } finally {
       setIsSubmitting(false);
@@ -240,7 +244,7 @@ export default function UpdateLotteryForm({
                     return (
                       <FormItem>
                         <FormLabel className="text-sm font-normal font-poopins">
-                          Evento
+                          Evento 
                         </FormLabel>
                         <Select
                           value={field.value ? field.value.toString() : ""}
@@ -250,7 +254,7 @@ export default function UpdateLotteryForm({
                           disabled={selectedCompanyId === 0}
                         >
                           <SelectTrigger className="border-[#9A7FFF] focus:ring-[#9A7FFF] font-poopins">
-                            <SelectValue placeholder="Seleccionar evento" />
+                            <SelectValue placeholder="Seleccionar evento opcional" />
                           </SelectTrigger>
                           <SelectContent>
                             {eventosDisponibles.length === 0 ? (
@@ -370,7 +374,7 @@ export default function UpdateLotteryForm({
                       <FormLabel className="text-sm font-normal font-poopins">
                         Fecha y Hora
                       </FormLabel>
-                      <DateTimePickerInline
+                      <DateTimePickerInlineLottery
                         value={field.value}
                         onChange={(date) => form.setValue("lottery_date", date)}
                       />


### PR DESCRIPTION
Se modificó la creación y edicción de loterías para permitir la asociación opcional de eventos y se ajustó la lógica del formulario en consecuencia. Se actualizó la página de loterías para gestionar correctamente los parámetros de paginación y mostrar una insignia cuando una lotería no está vinculada a un evento.